### PR TITLE
Menu for small devices

### DIFF
--- a/scss/pre.scss
+++ b/scss/pre.scss
@@ -23,7 +23,7 @@
 
 $mobile-break-point: 767px;
 $col2-break-point: 945px;
-$hamburger-menu-break-point: 1000px;
+$hamburger-menu-break-point: 1080px;
 $onecolumn-break-point: $mobile-break-point;
 
 

--- a/scss/wwu2019/menu.scss
+++ b/scss/wwu2019/menu.scss
@@ -72,7 +72,7 @@ ul[role="menubar"] {
     #main-menu-border {
         padding: 10px 0;
         border-bottom: 4px solid $dividergrey;
-
+        height: 100%;
         display: flex;
         flex-wrap: wrap-reverse;
     }
@@ -90,6 +90,14 @@ ul[role="menubar"] {
 
     .main-menu-additions-item {
         display: flex;
+
+        @for $i from 1 through 4 {
+            & > :nth-child(#{$i}) {
+                @media (max-width: #{500 - $i * 40}px) {
+                    display: none;
+                }
+            }
+        }
 
         .nav-link {
             padding: 0 15px 0 0;
@@ -317,6 +325,16 @@ ul[role="menubar"] {
             border-radius: 4px;
             margin-right: 4px;
             vertical-align: top;
+        }
+
+        .user-name {
+            max-width: 170px;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            height: 100%;
+            display: inline-block;
+            vertical-align: bottom;
+            white-space: nowrap;
         }
     }
 

--- a/scss/wwu2019/menu.scss
+++ b/scss/wwu2019/menu.scss
@@ -462,6 +462,7 @@ ul[role="menubar"] {
     }
 
     .search {
+        margin-top: 0;
         height: 100%;
 
         .search-field {

--- a/scss/wwu2019/menu.scss
+++ b/scss/wwu2019/menu.scss
@@ -93,6 +93,7 @@ ul[role="menubar"] {
 
         @for $i from 1 through 4 {
             & > :nth-child(#{$i}) {
+                // First item should disappear at 460px, second at 420px...
                 @media (max-width: #{500 - $i * 40}px) {
                     display: none;
                 }

--- a/templates/menu.mustache
+++ b/templates/menu.mustache
@@ -101,7 +101,7 @@
                 <li role="none" id="user-menu" aria-haspopup="true" aria-expanded="false">
                     <a role="menuitem" tabindex="0" {{# href }} href="{{ href }}"{{/href}}>
                         <img class="user-icon" src="{{pic}}" alt="PICTURE OF {{name}}" />
-                        <span class="underline">{{name}}</span>
+                        <span class="underline user-name">{{name}}</span>
                     </a>
                     <div class="sub-menu-scroll-wrapper">
                         <div class="sub-menu-scroll-container">


### PR DESCRIPTION
- Icons disappear one by one, if device-width is to small to display them
- Displayed Username is cut off at 170px (roughly about 15-16 characters)
- Hamburger menu shows already at device-width < 1080px, to prevent wrapping the main menu into two rows.
![image](https://user-images.githubusercontent.com/45795270/76714330-b74e4680-6726-11ea-81f2-77baf9f68c40.png)
![image](https://user-images.githubusercontent.com/45795270/76714347-cfbe6100-6726-11ea-8fc5-70edfc7b1b9e.png)
![image](https://user-images.githubusercontent.com/45795270/76714352-d4831500-6726-11ea-9b67-2fc417c88146.png)
