### PR TITLE
Remove standard layouts

### DIFF
--- a/config.php
+++ b/config.php
@@ -184,10 +184,10 @@ $THEME->layouts = [
         ),
         // The pagelayout used for safebrowser and securewindow.
         'secure' => array(
-                'theme' => 'classic',
+                'theme' => 'wwu2019',
                 'file' => 'secure.php',
-                'regions' => array('side-pre'),
-                'defaultregion' => 'side-pre'
+                'regions' => array('side-post'),
+                'defaultregion' => 'side-post'
         )
 ];
 

--- a/config.php
+++ b/config.php
@@ -65,7 +65,7 @@ $THEME->prescsscallback = 'theme_wwu2019_get_pre_scss';
 $THEME->layouts = [
         // Most backwards compatible layout without the blocks - this is the layout used by default.
         'base' => array(
-                'theme' => 'classic',
+                'theme' => 'wwu2019',
                 'file' => 'columns.php',
                 'regions' => array(),
         ),
@@ -136,14 +136,14 @@ $THEME->layouts = [
 
         // Pages that appear in pop-up windows - no navigation, no blocks, no header.
         'popup' => array(
-                'theme' => 'classic',
+                'theme' => 'wwu2019',
                 'file' => 'contentonly.php',
                 'regions' => array(),
                 'options' => array('nofooter' => true, 'nonavbar' => true),
         ),
         // No blocks and minimal footer - used for legacy frame layouts only!
         'frametop' => array(
-                'theme' => 'classic',
+                'theme' => 'wwu2019',
                 'file' => 'contentonly.php',
                 'regions' => array(),
                 'options' => array('nofooter' => true, 'nocoursefooter' => true),
@@ -164,7 +164,7 @@ $THEME->layouts = [
         ),
         // Should display the content and basic headers only.
         'print' => array(
-                'theme' => 'classic',
+                'theme' => 'wwu2019',
                 'file' => 'contentonly.php',
                 'regions' => array(),
                 'options' => array('nofooter' => true, 'nonavbar' => false),

--- a/layout/contentonly.php
+++ b/layout/contentonly.php
@@ -28,7 +28,10 @@ defined('MOODLE_INTERNAL') || die();
 
 layout::sso_auto_login();
 
-$templatecontext = layout::get_default_template_context();
+$templatecontext = [
+        'bodyattributes' => $OUTPUT->body_attributes(),
+        'output' => $OUTPUT
+];
 
-echo $OUTPUT->render_from_template('theme_wwu2019/secure', $templatecontext);
+echo $OUTPUT->render_from_template('theme_wwu2019/contentonly', $templatecontext);
 

--- a/layout/secure.php
+++ b/layout/secure.php
@@ -1,0 +1,36 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Layout for the WWU 2019 Theme.
+ *
+ * @package   theme_wwu2019
+ * @copyright 2019 Justus Dieckmann WWU
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+use theme_wwu2019\layout;
+
+defined('MOODLE_INTERNAL') || die();
+
+$OUTPUT->doctype();
+
+layout::sso_auto_login();
+
+$templatecontext = layout::get_default_template_context();
+
+echo $OUTPUT->render_from_template('theme_wwu2019/secure', $templatecontext);
+

--- a/templates/contentonly.mustache
+++ b/templates/contentonly.mustache
@@ -15,11 +15,7 @@
     along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 }}
 {{!
-    @template theme_wwu2019/simple
-
-    Admin time setting template.
-
-    Classic 1-3 column layout template.
+    @template theme_wwu2019/contentonly
 }}
 {{{ output.doctype }}}
 <html {{{ output.htmlattributes }}}>

--- a/templates/contentonly.mustache
+++ b/templates/contentonly.mustache
@@ -1,0 +1,66 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template theme_wwu2019/simple
+
+    Admin time setting template.
+
+    Classic 1-3 column layout template.
+}}
+{{{ output.doctype }}}
+<html {{{ output.htmlattributes }}}>
+<head>
+    <title>{{{ output.page_title }}}</title>
+    <link rel="shortcut icon" href="{{{ output.favicon }}}" />
+    {{{ output.standard_head_html }}}
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+
+<body {{{ bodyattributes }}}>
+
+<div id="page-wrapper">
+
+    {{{ output.standard_top_of_body_html }}}
+
+    <div id="page">
+
+        <div id="page-content" class="row">
+            <div id="region-main-box" class="region-main mb-3">
+                <section id="region-main" class="region-main-content" aria-label="{{#str}}content{{/str}}">
+                    {{{ output.course_content_header }}}
+                    <div id="region-main-body">
+                        {{{ output.main_content }}}
+                        {{{ output.activity_navigation }}}
+                        {{{ output.course_content_footer }}}
+                    </div>
+                </section>
+            </div>
+        </div>
+    </div>
+    {{{ output.standard_after_main_region_html }}}
+</div>
+
+{{{ output.matomo_insert_html }}}
+
+</body>
+</html>
+{{#js}}
+M.util.js_pending('theme_boost/loader');
+require(['theme_boost/loader'], function() {
+  M.util.js_complete('theme_boost/loader');
+});
+{{/js}}

--- a/templates/secure.mustache
+++ b/templates/secure.mustache
@@ -17,10 +17,6 @@
 {{!
     @template theme_wwu2019/secure
 
-    Admin time setting template.
-
-    Classic 1-3 column layout template.
-
     Context variables required for this template:
     * sitename - The name of the site
     * output - The core renderer for the page

--- a/templates/secure.mustache
+++ b/templates/secure.mustache
@@ -1,0 +1,92 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template theme_wwu2019/secure
+
+    Admin time setting template.
+
+    Classic 1-3 column layout template.
+
+    Context variables required for this template:
+    * sitename - The name of the site
+    * output - The core renderer for the page
+    * bodyattributes - attributes for the body tag as a string of html attributes
+    * hasblocks - true if there are blocks on this page
+    * regionmainsettingsmenu - HTML for the region main settings menu
+    * hasregionmainsettingsmenu - There is a region main settings menu on this page.
+
+    Example context (json):
+    {
+        "sitename": "Moodle",
+        "output": {
+            "doctype": "<!DOCTYPE html>",
+            "page_title": "Test page",
+            "favicon": "favicon.ico",
+            "main_content": "<h1>Headings make html validators happier</h1>"
+         },
+        "bodyattributes":"",
+        "sidepostblocks": "<h2>Blocks html goes here</h2>",
+        "haspostblocks":true
+    }
+}}
+{{> theme_boost/head }}
+
+<body {{{ bodyattributes }}}>
+
+<div id="page-wrapper">
+
+    {{{ output.standard_top_of_body_html }}}
+
+    <div id="page">
+        {{{ output.logo_header }}}
+
+        <div class="my-2"></div>
+
+        <div id="page-content" class="row {{#haspostblocks}} blocks-post {{/haspostblocks}}">
+            <div id="region-main-box" class="region-main mb-3">
+                <section id="region-main" class="region-main-content" aria-label="{{#str}}content{{/str}}">
+                    {{{ output.course_content_header }}}
+                    <div id="region-main-body">
+                        {{{ output.main_content }}}
+                        {{{ output.activity_navigation }}}
+                        {{{ output.course_content_footer }}}
+                    </div>
+                </section>
+            </div>
+
+            <div class="columnright blockcolumn {{#haspostblocks}} has-blocks {{/haspostblocks}}">
+                <section data-region="blocks-column" class="hidden-print" aria-label="{{#str}}blocks{{/str}}">
+                    {{{ sidepostblocks }}}
+                </section>
+            </div>
+        </div>
+    </div>
+    {{{ output.standard_after_main_region_html }}}
+    {{> theme_wwu2019/footer }}
+
+</div>
+
+{{{ output.matomo_insert_html }}}
+
+</body>
+</html>
+{{#js}}
+M.util.js_pending('theme_boost/loader');
+require(['theme_boost/loader'], function() {
+  M.util.js_complete('theme_boost/loader');
+});
+{{/js}}


### PR DESCRIPTION
Now, every pagelayout except `maintenance` and `embedded` is rendered by wwu2019. Maintenance and embedded only show content, and no headers or footers.
Fixes #43 