### PR TITLE
adjusted sql statement to order courses in main navigation

### DIFF
--- a/classes/output/core_renderer.php
+++ b/classes/output/core_renderer.php
@@ -513,7 +513,7 @@ class core_renderer extends \core_renderer {
                                 INNER JOIN mdl_customfield_data as cd ON cs.id=cd.instanceid
                                 WHERE cs.id ' . $instring . '
                                 AND cd.fieldid = :fieldid
-                                ORDER BY cd.value DESC, cs.shortname ASC';
+                                ORDER BY cd.intvalue DESC, cs.shortname ASC';
         $params['fieldid'] = $fieldid;
         return $DB->get_records_sql($fromtable, $params);
     }


### PR DESCRIPTION
Previously the sql statement used a char column to order entries. Now it orders all entries due to an integer column. 