### PR TITLE
Put footer in #page to allow menu to scroll into footer as well

### DIFF
--- a/scss/wwu2019/general.scss
+++ b/scss/wwu2019/general.scss
@@ -152,11 +152,7 @@ $page-padding: 1rem;
 /* Footer */
 footer#wwu-footer {
     width: 100%;
-    max-width: 1440px;
-    padding: 16px;
     position: relative;
-    margin-left: auto;
-    margin-right: auto;
 
     .wwu-card {
         background-color: $wwu-footer;

--- a/scss/wwu2019/general.scss
+++ b/scss/wwu2019/general.scss
@@ -225,6 +225,11 @@ footer#wwu-footer {
     }
 }
 
+// Remove padding from standard moodle-footer.
+footer#wwu-footer + div > div.container {
+    padding: 0;
+}
+
 .performanceinfo .cachesused .cache-definition-stats-heading {
     color: map-get($theme-colors, 'light');
 }

--- a/templates/columns.mustache
+++ b/templates/columns.mustache
@@ -84,10 +84,9 @@
                 </section>
             </div>
         </div>
+        {{{ output.standard_after_main_region_html }}}
+        {{> theme_wwu2019/footer }}
     </div>
-    {{{ output.standard_after_main_region_html }}}
-    {{> theme_wwu2019/footer }}
-
 </div>
 
 {{{ output.matomo_insert_html }}}

--- a/templates/contentonly.mustache
+++ b/templates/contentonly.mustache
@@ -46,8 +46,8 @@
                 </section>
             </div>
         </div>
+        {{{ output.standard_after_main_region_html }}}
     </div>
-    {{{ output.standard_after_main_region_html }}}
 </div>
 
 {{{ output.matomo_insert_html }}}

--- a/templates/frontpage.mustache
+++ b/templates/frontpage.mustache
@@ -110,10 +110,9 @@
                 </section>
             </div>
         </div>
+        {{{ output.standard_after_main_region_html }}}
+        {{> theme_wwu2019/footer }}
     </div>
-    {{{ output.standard_after_main_region_html }}}
-    {{> theme_wwu2019/footer }}
-
 </div>
 
 </body>

--- a/templates/secure.mustache
+++ b/templates/secure.mustache
@@ -70,10 +70,9 @@
                 </section>
             </div>
         </div>
+        {{{ output.standard_after_main_region_html }}}
+        {{> theme_wwu2019/footer }}
     </div>
-    {{{ output.standard_after_main_region_html }}}
-    {{> theme_wwu2019/footer }}
-
 </div>
 
 {{{ output.matomo_insert_html }}}


### PR DESCRIPTION
The menu sticks to the top of frame inside the `#page` div. Because the footer is located outside of `#page`, when scrolling down completely on small devices, `#page` might get scrolled outside the viewport and the menu would be hidden.

![image](https://user-images.githubusercontent.com/45795270/78384745-09beac80-75db-11ea-8970-9546241268a5.png)

This might be fixed by moving the footer inside `#page`.
