### PR TITLE
Slideshow: Hide overflow of carousel-items

### DIFF
--- a/scss/wwu2019/slideshow.scss
+++ b/scss/wwu2019/slideshow.scss
@@ -81,4 +81,8 @@
     .carousel-control-prev-icon {
         height: 35px;
     }
+
+    .carousel-item {
+        overflow: hidden;
+    }
 }


### PR DESCRIPTION
Prevents this from happening during a slide transition:
![image](https://user-images.githubusercontent.com/45795270/79879561-25092480-83ef-11ea-9667-5ef4e3c56dca.png)