### PR TITLE
Fixes hightlighted sections and margins for topcoll format

### DIFF
--- a/scss/wwu2019/courselayout.scss
+++ b/scss/wwu2019/courselayout.scss
@@ -215,6 +215,17 @@ body.format-topcoll {
         }
     }
 
+    .course-content .current::before {
+        content: none;
+    }
+
+    &:not(.editing) .course-content ul.topics li.section .left,
+    &:not(.editing) .course-content ul.topics li.section .right,
+    &:not(.editing) .course-content ul.weeks li.section .left,
+    &:not(.editing) .course-content ul.weeks li.section .right {
+        display: inherit;
+    }
+
     /** Toggle **/
 
     .course-content ul.ctopics li.section .header span.the_toggle {


### PR DESCRIPTION
Before:
![Screenshot from 2020-09-21 23-05-05](https://user-images.githubusercontent.com/45795270/93822589-bf9cb680-fc60-11ea-89c0-035e13da8348.png)
After:
![Screenshot from 2020-09-21 23-10-41](https://user-images.githubusercontent.com/45795270/93822633-cb887880-fc60-11ea-88d4-f608646d2696.png)
