### PR TITLE
adds support for the progresstopics format

### DIFF
--- a/classes/output/format_progresstopics_renderer.php
+++ b/classes/output/format_progresstopics_renderer.php
@@ -1,0 +1,82 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Overriden functions for format_topics_renderer and format_section_renderer_base.
+ *
+ * @package theme_wwu2019
+ * @copyright 2020 Justus Dieckmann WWU
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace theme_wwu2019\output;
+
+use html_writer;
+use stdClass;
+
+defined('MOODLE_INTERNAL') || die();
+require_once($CFG->dirroot . '/course/format/topics/renderer.php');
+
+/**
+ * Overriden functions for format_topics_renderer and format_section_renderer_base.
+ *
+ * @copyright 2020 Justus Dieckmann WWU
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class format_progresstopics_renderer extends \format_progresstopics_renderer {
+    use wwu_format_trait;
+
+    /**
+     * Generate the display of the header part of a section before
+     * course modules are included
+     *
+     * @param stdClass $section The course_section entry from DB
+     * @param stdClass $course The course entry from DB
+     * @param bool $onsectionpage true if being printed on a single-section page
+     * @param int $sectionreturn The section to return to after an action
+     * @return string HTML to output.
+     */
+    protected function section_header($section, $course, $onsectionpage, $sectionreturn = null) {
+        return $this->wwu_section_header($section, $course, $onsectionpage);
+    }
+
+    /**
+     * Generate a summary of a section for display on the 'course index page'
+     *
+     * @param stdClass $section The course_section entry from DB
+     * @param stdClass $course The course entry from DB
+     * @param array    $mods (argument not used)
+     * @return string HTML to output.
+     */
+    protected function section_summary($section, $course, $mods) {
+        return $this->wwu_section_summary($section, $course, $mods);
+    }
+
+    /**
+     * Output the html for a single section page .
+     *
+     * @param stdClass $course The course entry from DB
+     * @param array $sections (argument not used)
+     * @param array $mods (argument not used)
+     * @param array $modnames (argument not used)
+     * @param array $modnamesused (argument not used)
+     * @param int $displaysection The section number in the course which is being displayed
+     */
+    public function print_single_section_page($course, $sections, $mods, $modnames, $modnamesused, $displaysection) {
+        $this->wwu_print_single_section_page($course, $sections, $mods, $modnames, $modnamesused, $displaysection);
+    }
+
+}


### PR DESCRIPTION
The progresstopics format is a new format and therefore needs to be supported by the theme.
Provides functionality to correctly display the headers for each topic