### PR TITLE
Remove space above course block header in editing mode

### DIFF
--- a/classes/output/wwu_format_trait.php
+++ b/classes/output/wwu_format_trait.php
@@ -67,9 +67,6 @@ trait wwu_format_trait {
             'class' => 'section main clearfix' . $sectionstyle, 'role' => 'region',
             'aria-label' => get_section_name($course, $section)));
 
-        // Create a span that contains the section title to be used to create the keyboard section move menu.
-        $o .= html_writer::tag('span', get_section_name($course, $section), array('class' => 'hidden sectionname'));
-
         $o .= html_writer::start_div('header');
 
         $leftcontent = $this->section_left_content($section, $course, $onsectionpage);

--- a/scss/wwu2019/courselayout.scss
+++ b/scss/wwu2019/courselayout.scss
@@ -98,7 +98,6 @@ body.pagelayout-course {
         .content {
             margin: 0;
             padding: 12px 4px;
-            overflow-x: auto;
 
             .section {
                 margin: 0;


### PR DESCRIPTION
Also: Revert scroll course blocks on horizontal overflow, because bugs.