### PR TITLE
Slideshow: Fix mainly for high aspect ratio images

### DIFF
--- a/scss/wwu2019/slideshow.scss
+++ b/scss/wwu2019/slideshow.scss
@@ -60,11 +60,15 @@
     }
 
     .carousel-image-container {
-        height: 260px;
+        max-height: 260px;
         padding: 8px;
-        max-width: 100%;
+        max-width: 66%;
         flex-shrink: 0;
         object-fit: contain;
+
+        @media (max-width: 768px) {
+            max-width: 100%;
+        }
     }
 
     .side-caption {


### PR DESCRIPTION
![Screenshot from 2021-09-14 15-04-15](https://user-images.githubusercontent.com/45795270/133262702-009751dc-6d67-4a80-8f6a-3f207ebaadc1.png)

Images can now occupy 66% of container at most.