### PR TITLE
Fix uncentered blue icons

### DIFF
--- a/scss/wwu2019/courselayout.scss
+++ b/scss/wwu2019/courselayout.scss
@@ -98,7 +98,7 @@ body.pagelayout-course {
             }
         }
 
-        .content {
+        &> .content {
             margin: 0;
             padding: 0 0.5rem 0.5rem;
             // overflow-x: auto;


### PR DESCRIPTION
Extremely severe problem: 
![image](https://user-images.githubusercontent.com/45795270/199348461-f83a0272-a545-4b44-84ce-1e4afa0da558.png)

Now fixed:
![image](https://user-images.githubusercontent.com/45795270/199348546-df7efc2d-f04f-4496-b22c-e38a29ffea7a.png)
