### PR TITLE
Switch over to new Uni MS logo

### DIFF
--- a/scss/wwu2019/general.scss
+++ b/scss/wwu2019/general.scss
@@ -112,14 +112,15 @@ $page-padding: 1rem;
         text-align: left;
         display: block;
         height: 81px;
-        width: 280px;
+        width: 302px;
         background-size: contain;
         background-position: left center;
         background-repeat: no-repeat;
-        background-image: url("https://www.uni-muenster.de/imperia/md/images/allgemein/farbunabhaengig/wwu.svg");
+        background-image: url("https://www.uni-muenster.de/imperia/md/images/allgemein/farbunabhaengig/unims.svg");
+        float: left;
 
         @media (max-width: $mobile-break-point) {
-            background-position: -82px center;
+            background-position: -76px center;
             background-size: cover;
             width: 81px;
         }
@@ -135,6 +136,7 @@ $page-padding: 1rem;
         background-image: url(#{$wwwroot}/theme/wwu2019/pix/#{$logoprefix}_light.svg);
         background-repeat: no-repeat;
         background-size: contain;
+        float: right;
     }
 }
 

--- a/scss/wwu2019/theming.scss
+++ b/scss/wwu2019/theming.scss
@@ -12,7 +12,7 @@
     --wwu-muted-fg: #ced4da;
     --wwu-contrast-fg: #000;
     --wwu-outlinegrey: #bec6c8;
-    --wwu-dividergrey: #423c39;
+    --wwu-dividergrey: #333f48;
     --wwu-learnwebblue: #{$learnwebblue};
     --wwu-learnwebblue-highlight: #{darken($learnwebblue, 15%)};
     --wwu-learnwebblue-og: #{$learnwebblue};


### PR DESCRIPTION
with changed dividergray (second commit):
![Screenshot from 2023-09-18 16-13-33](https://github.com/learnweb/moodle-theme_wwu2019/assets/45795270/8b562172-5a61-444d-b6eb-e42597a4a08d)

without:
![image](https://github.com/learnweb/moodle-theme_wwu2019/assets/45795270/b8de58b6-a418-45f3-809f-11fa629d1ad4)